### PR TITLE
#1 wrapping forms in lambda expression to allow use of def and defn in submitted code 

### DIFF
--- a/src/lambda_zone/backend.clj
+++ b/src/lambda_zone/backend.clj
@@ -386,7 +386,6 @@
 
 
 (defn find-def-exprs [exprs]
-  "TODO this is wrong btw, (def f (fn [a] (+ 1 a))) would match it but is not a variable binding, not sure if it matters or not (TEST!)"
   (filter #(-> % first (= 'def)) exprs))
 
 (defn find-defn-exprs [exprs]

--- a/src/lambda_zone/backend.clj
+++ b/src/lambda_zone/backend.clj
@@ -437,13 +437,11 @@
          (-main# board#)))))
 
 ; we have to check if it's not already a lambda and do nothing then
-(defn validate-format [exprs]
-  (if (not-lambda-expression? exprs)
-    (if (and (coll? exprs) (coll? (first exprs)))
-      (wrap-forms-in-lambda exprs)
-      (wrap-forms-in-lambda [exprs]))
+(defn validate-code-format [[first & rest :as forms]]
+  (if (not-lambda-expression? first)
+    (wrap-forms-in-lambda forms)
     ;user created a single lamda, not need to wrap
-     exprs ))
+     first))
 
 
 
@@ -521,7 +519,7 @@
 ;;(parse-error? {:result :not-valid-clojure-form})
 
 (defn validate-fn [src]
-  (let [form (validate-format (validate-read-string src))]
+  (let [form (validate-code-format (validate-read-string (str "[" src "]")))]
     (if (parse-error? form)
       form
       (let [{res-validation :result :as val-form} (validate-form form)]

--- a/test/clj_chess_engine/core_test.clj
+++ b/test/clj_chess_engine/core_test.clj
@@ -957,7 +957,7 @@
 
 (comment
                                         ;TODO create a test
-  (lz/wrap-exprs-in-lambda '(
+  (lz/validate-format '(
                           (def a 12)
                           (defn b [c] (+ a c))
                           (defn random-f
@@ -991,7 +991,7 @@
 
 (comment
 ;TODO create a test
-  (lz/find-defn-exprs-less-main '( (def a 1) (defn b [] (+ 1 1)) (defn -main [] (b)) (defn f [a b] (+ a b))))
+  (lz/find-defn-forms-less-main '( (def a 1) (defn b [] (+ 1 1)) (defn -main [] (b)) (defn f [a b] (+ a b))))
 
   )
 
@@ -1004,7 +1004,7 @@
 
 (comment
   (lz/validate-form
-   (lz/wrap-exprs-in-lambda
+   (lz/validate-format
     (read-string "((def a 12)
                           (defn b [c] (+ a c))
                           (defn random-f

--- a/test/clj_chess_engine/core_test.clj
+++ b/test/clj_chess_engine/core_test.clj
@@ -896,12 +896,12 @@
 
 (deftest if-lambda-expr-already-dont-rewrite
   (is "no wrapping if already a single lambda expression"
-      (= (lz/validate-format
-          '(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
-  (let [v (into [] valid-moves)
-        iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
-    (let [move (rand-int (count valid-moves))]
-      {:move (get v move) :state iteration})) ))
+      (= (lz/validate-code-format
+          '((fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
+               (let [v (into [] valid-moves)
+                     iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
+                 (let [move (rand-int (count valid-moves))]
+                   {:move (get v move) :state iteration})) )))
          '(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
   (let [v (into [] valid-moves)
         iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
@@ -910,7 +910,7 @@
 
 (deftest when-exprs-wrap-in-lambda
   (is "when user provides list of expressions, not single lambda, expect wrapping"
-      (= (first (lz/validate-format
+      (= (first (lz/validate-code-format
                  '((def i 1)
                    (defn get-iteration [s]
                      (if (nil? s) (+ i (if am-i-white? 0 1)) (+ 2 (count  s))))
@@ -922,6 +922,38 @@
                          {:move (get v move), :state iteration})))
                    (defn -main [board] (do (println "Starting move") (random-f board))))))
          'clojure.core/fn)))
+
+(deftest when-string-with-forms-not-wrapped-expect-result-ok
+  (is "when user provides list of def and defn expressions wrap them in list of forms and expect to pass validation"
+      (= (lz/validate-fn "(def a 12)
+                          (defn b [c] (+ a c))
+                          (defn random-f
+                            [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+                            (let [v (into [] valid-moves)
+                                  iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 (count  s)))]
+                              (let [move (rand-int (count valid-moves))]
+                                {:move (get v move), :state iteration})))
+                          (defn -main [board] (do (println (b a )) (random-f board)))")
+         {:result :ok})))
+
+(deftest when-string-with-forms-not-wrapped-expect-result-ok
+  (is "when user provides list of def and defn expressions wrap them in list of forms and expect to pass validation"
+      (= (lz/validate-fn "(def -main (fn
+                            [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+                            (let [v (into [] valid-moves)
+                                  iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 (count  s)))]
+                              (let [move (rand-int (count valid-moves))]
+                                {:move (get v move), :state iteration}))))")
+         {:result :ok})))
+
+(deftest when-string-with-forms-not-wrapped-expect-result-ok
+  (is "when user provides list of def and defn expressions wrap them in list of forms and expect to pass validation"
+      (= (lz/validate-fn "(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
+                           (let [v (into [] valid-moves)
+                                 iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
+                             (let [move (rand-int (count valid-moves))]
+                               {:move (get v move) :state iteration})) )")
+         {:result :ok})))
 
 (comment
 '(
@@ -939,7 +971,7 @@
     (defn -main [board] (do (println "Starting move") (random-f board)))))
 
 (comment
-  (sb (lz/wrap-exprs-in-lambda '(
+  (sb (lz/validate-code-format '(
 
     (def i 1)
     (defn get-iteration [s am-i-white?]
@@ -957,7 +989,7 @@
 
 (comment
                                         ;TODO create a test
-  (lz/validate-format '(
+  (lz/validate-code-format '(
                           (def a 12)
                           (defn b [c] (+ a c))
                           (defn random-f
@@ -967,12 +999,12 @@
                               (let [move (rand-int (count valid-moves))]
                                 {:move (get v move), :state iteration})))
                           (defn -main [board] (do (println (b a )) (random-f board)))))
-  (lz/validate-format '(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
-                           (let [v (into [] valid-moves)
-                                 iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
-                             (let [move (rand-int (count valid-moves))]
-                               {:move (get v move) :state iteration})) ))
-  (lz/validate-format '(def -main (fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
+  (lz/validate-code-format '( (fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
+                                (let [v (into [] valid-moves)
+                                      iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
+                                  (let [move (rand-int (count valid-moves))]
+                                    {:move (get v move) :state iteration})) )))
+  (lz/validate-code-format '(def -main (fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
                            (let [v (into [] valid-moves)
                                  iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
                              (let [move (rand-int (count valid-moves))]
@@ -994,6 +1026,7 @@
 
     )
 
+
 (comment
 ;TODO create a test
   (lz/find-defn-forms-less-main '( (def a 1) (defn b [] (+ 1 1)) (defn -main [] (b)) (defn f [a b] (+ a b))))
@@ -1009,8 +1042,8 @@
 
 (comment
   (lz/validate-form
-   (lz/validate-format
-    (read-string "((def a 12)
+   (lz/validate-code-format
+    (read-string "[(def a 12)
                           (defn b [c] (+ a c))
                           (defn random-f
                             [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
@@ -1018,12 +1051,12 @@
                                   iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 (count  s)))]
                               (let [move (rand-int (count valid-moves))]
                                 {:move (get v move), :state iteration})))
-                          (defn -main [board] (do (println (b a )) (random-f board))))"))))
+                          (defn -main [board] (do (println (b a )) (random-f board)))]"))))
 
 (comment
   (lz/validate-compile-exec
-   (lz/wrap-exprs-in-lambda
-    (read-string "((def a 12)
+   (lz/validate-format
+    (read-string "(def a 12)
                           (defn b [c] (+ a c))
                           (defn random-f
                             [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
@@ -1031,7 +1064,7 @@
                                   iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 (count  s)))]
                               (let [move (rand-int (count valid-moves))]
                                 {:move (get v move), :state iteration})))
-                          (defn -main [board] (do (println (b a )) (random-f board))))")))
+                          (defn -main [board] (do (println (b a )) (random-f board)))")))
   )
 
 (comment

--- a/test/clj_chess_engine/core_test.clj
+++ b/test/clj_chess_engine/core_test.clj
@@ -1,5 +1,6 @@
 (ns clj-chess-engine.core-test
   (:require [clojure.test :refer :all]
+            [lambda-zone.backend :as lz]
             [clj-chess-engine.core :refer :all]))
 
 (def en-passant-check-board ;; it's white's turn
@@ -866,3 +867,201 @@
 ;;  \- \- \- \- \P \- \- \-
 ;;  \- \- \- \N \B \- \R \-
 ;;  \R \- \K \- \- \- \- \-]
+
+
+;;TODO rewrite as test
+
+(comment
+                                        ;TODO create a test
+  (wrap-exprs-in-lambda '(
+                          (def a 12)
+                          (defn b [c] (+ a c))
+                          (defn random-f
+                            [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+                            (let [v (into [] valid-moves)
+                                  iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 (count  s)))]
+                              (let [move (rand-int (count valid-moves))]
+                                {:move (get v move), :state iteration})))
+                          (defn -main [board] (do (println (b a )) (random-f board)))))
+  (wrap-exprs-in-lambda '(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
+                           (let [v (into [] valid-moves)
+                                 iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
+                             (let [move (rand-int (count valid-moves))]
+                               {:move (get v move) :state iteration})) ))
+  )
+
+;; (defn eval-form-safely [form]
+;;   (fn [in] ((chess/sb) (list form in))))
+
+
+(deftest if-lambda-expr-already-dont-rewrite
+  (is "no wrapping if already a single lambda expression"
+      (= (lz/wrap-exprs-in-lambda
+          '(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
+  (let [v (into [] valid-moves)
+        iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
+    (let [move (rand-int (count valid-moves))]
+      {:move (get v move) :state iteration})) ))
+         '(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
+  (let [v (into [] valid-moves)
+        iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
+    (let [move (rand-int (count valid-moves))]
+      {:move (get v move) :state iteration})) ))))
+
+(deftest when-exprs-wrap-in-lambda
+  (is "when user provides list of expressions, not single lambda, expect wrapping"
+      (= (first (lz/wrap-exprs-in-lambda
+                 '((def i 1)
+                   (defn get-iteration [s]
+                     (if (nil? s) (+ i (if am-i-white? 0 1)) (+ 2 (count  s))))
+                   (defn random-f
+                     [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+                     (let [v (into [] valid-moves)
+                           iteration (get-iteration s)]
+                       (let [move (rand-int (count valid-moves))]
+                         {:move (get v move), :state iteration})))
+                   (defn -main [board] (do (println "Starting move") (random-f board))))))
+         'clojure.core/fn)))
+
+(comment
+'(
+
+    (def i 1)
+    (defn get-iteration [s am-i-white?]
+      (if (nil? s) (+ i (if am-i-white? 0 1)) (+ 2 (count  s))))
+
+    (defn random-f
+      [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+      (let [v (into [] valid-moves)
+            iteration (get-iteration s am-i-white?)]
+        (let [move (rand-int (count valid-moves))]
+          {:move (get v move), :state iteration})))
+    (defn -main [board] (do (println "Starting move") (random-f board)))))
+
+(comment
+  (sb (lz/wrap-exprs-in-lambda '(
+
+    (def i 1)
+    (defn get-iteration [s am-i-white?]
+      (if (nil? s) (+ i (if am-i-white? 0 1)) (+ 2 (count  s))))
+
+    (defn random-f
+      [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+      (let [v (into [] valid-moves)
+            iteration (get-iteration s am-i-white?)]
+        (let [move (rand-int (count valid-moves))]
+          {:move (get v move), :state iteration})))
+    (defn -main [board] (do (println "Starting move") (random-f board)))))))
+
+
+
+(comment
+                                        ;TODO create a test
+  (lz/wrap-exprs-in-lambda '(
+                          (def a 12)
+                          (defn b [c] (+ a c))
+                          (defn random-f
+                            [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+                            (let [v (into [] valid-moves)
+                                  iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 (count  s)))]
+                              (let [move (rand-int (count valid-moves))]
+                                {:move (get v move), :state iteration})))
+                          (defn -main [board] (do (println (b a )) (random-f board)))))
+  (lz/wrap-exprs-in-lambda '(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
+                           (let [v (into [] valid-moves)
+                                 iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
+                             (let [move (rand-int (count valid-moves))]
+                               {:move (get v move) :state iteration})) ))
+
+    (lz/find-main '(
+
+     (def i 1)
+     (defn get-iteration [s]
+       (if (nil? s) (+ i (if am-i-white? 0 1)) (+ 2 (count  s))))
+
+     (defn random-f
+       [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+       (let [v (into [] valid-moves)
+             iteration (get-iteration s)]
+         (let [move (rand-int (count valid-moves))]
+           {:move (get v move), :state iteration})))
+     (defn -main [board] (do (println "Starting move") (random-f board)))))
+
+    )
+
+(comment
+;TODO create a test
+  (lz/find-defn-exprs-less-main '( (def a 1) (defn b [] (+ 1 1)) (defn -main [] (b)) (defn f [a b] (+ a b))))
+
+  )
+
+(comment
+  ;TODO create a test
+  (lz/find-main '( (def a 1) (defn b [] (+ 1 1)) (defn -main [] (b)) (defn f [a b] (+ a b))))
+  (lz/find-main '( (def a 1) (defn b [] (+ 1 1)) (defn f [a b] (+ a b))))
+  )
+
+
+(comment
+  (lz/validate-form
+   (lz/wrap-exprs-in-lambda
+    (read-string "((def a 12)
+                          (defn b [c] (+ a c))
+                          (defn random-f
+                            [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+                            (let [v (into [] valid-moves)
+                                  iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 (count  s)))]
+                              (let [move (rand-int (count valid-moves))]
+                                {:move (get v move), :state iteration})))
+                          (defn -main [board] (do (println (b a )) (random-f board))))"))))
+
+(comment
+  (lz/validate-compile-exec
+   (lz/wrap-exprs-in-lambda
+    (read-string "((def a 12)
+                          (defn b [c] (+ a c))
+                          (defn random-f
+                            [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+                            (let [v (into [] valid-moves)
+                                  iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 (count  s)))]
+                              (let [move (rand-int (count valid-moves))]
+                                {:move (get v move), :state iteration})))
+                          (defn -main [board] (do (println (b a )) (random-f board))))")))
+  )
+
+(comment
+
+
+  (lz/validate-fn "(
+    (def a 12)
+                          (defn b [c] (+ a c))
+                          (defn random-f
+                            [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+                            (let [v (into [] valid-moves)
+                                  iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 (count  s)))]
+                              (let [move (rand-int (count valid-moves))]
+                                {:move (get v move), :state iteration})))
+                          (defn -main [board] (do (println (b a )) (random-f board))))")
+
+  (lz/validate-compile-exec (-> "((ns my-game
+      (:require [clojure.pprint :as pp]))
+(def a 12)
+                          (defn b [c] (+ a c))
+                          (defn random-f
+                            [{board :board, am-i-white? :white-turn?, valid-moves :valid-moves, ic :in-check?, h :history, s :state}]
+                            (let [v (into [] valid-moves)
+                                  iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 (count  s)))]
+                              (let [move (rand-int (count valid-moves))]
+                                {:move (get v move), :state iteration})))
+                          (defn -main [board] (do (println (b a )) (random-f board))))"
+                     lz/validate-read-string
+                     lz/wrap-exprs-in-lambda
+                     lz/validate-form
+                     ))
+  )
+
+
+(comment
+  ;create a unit test
+  (lz/find-defn-exprs '( (def a 1) (defn b [] (+ 1 1)) (defn -main [] (b)) (defn f [a b] (+ a b))))
+  )

--- a/test/clj_chess_engine/core_test.clj
+++ b/test/clj_chess_engine/core_test.clj
@@ -896,7 +896,7 @@
 
 (deftest if-lambda-expr-already-dont-rewrite
   (is "no wrapping if already a single lambda expression"
-      (= (lz/wrap-exprs-in-lambda
+      (= (lz/validate-format
           '(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
   (let [v (into [] valid-moves)
         iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
@@ -910,7 +910,7 @@
 
 (deftest when-exprs-wrap-in-lambda
   (is "when user provides list of expressions, not single lambda, expect wrapping"
-      (= (first (lz/wrap-exprs-in-lambda
+      (= (first (lz/validate-format
                  '((def i 1)
                    (defn get-iteration [s]
                      (if (nil? s) (+ i (if am-i-white? 0 1)) (+ 2 (count  s))))
@@ -967,11 +967,16 @@
                               (let [move (rand-int (count valid-moves))]
                                 {:move (get v move), :state iteration})))
                           (defn -main [board] (do (println (b a )) (random-f board)))))
-  (lz/wrap-exprs-in-lambda '(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
+  (lz/validate-format '(fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
                            (let [v (into [] valid-moves)
                                  iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
                              (let [move (rand-int (count valid-moves))]
                                {:move (get v move) :state iteration})) ))
+  (lz/validate-format '(def -main (fn random-f [{board :board am-i-white? :white-turn valid-moves :valid-moves ic :in-check? h :history s :state}]
+                           (let [v (into [] valid-moves)
+                                 iteration (if (nil? s) (+ 1 (if am-i-white? 0 1)) (+ 2 s))]
+                             (let [move (rand-int (count valid-moves))]
+                               {:move (get v move) :state iteration})) )))
 
     (lz/find-main '(
 


### PR DESCRIPTION
- most of new logic is inside wrap-exprs-in-lambda function that uses few helper functions defined above
- integration point with your code is validate-fn function where I added an extra step [forms (wrap-exprs-in-lambda (validate-read-string src))] after  string->forms parsing and before further format validation. That way all of your validation code that check proper single lambda format is still reused, as it's executed after wrapping is performed. 
- If user already submitted a single lambda, then my function will return it without modification
- there is a concept of MAIN function, that is a function that will eventually be used as strategy from inside the wrapped lambda and I need a way to differentiate it from other 'helper' functions. Currently I'm looking for (defn '-main ...) expression and if it's not found I'm just taking last defn expression and treating is as MAIN. I hope that's acceptable
